### PR TITLE
Fixes #37: search dialog now works as in Drupal

### DIFF
--- a/js/search-reference.js
+++ b/js/search-reference.js
@@ -5,16 +5,21 @@
       // We can't combine all of these, since that causes
       // JQuery.each() to freak ut.'
       var selector = null;
-      if ($('table.views-table').size() > 0) {
-        selector = $('table.views-table tbody tr:not(.views-table-row-select-all)');
+      // Check for elements matching any of the desired selectors.
+      if ($('table.views-table', context).length > 0) {
+        // Use the views-table if found.
+        selector = $('table.views-table tbody tr:not(.views-table-row-select-all)', context);
       }
-      else if ($('table.views-view-grid').size() > 0) {
-        selector = $('table.views-view-grid td');
+      else if ($('table.views-view-grid', context).length > 0) {
+        // Use views-view-grid if found.
+        selector = $('table.views-view-grid td', context);
       }
-      else if ($('.views-row').size() > 0) {
-        selector = $('.views-row');
+      else if ($('.views-row', context).length > 0) {
+        // Use views-row if found.
+        selector = $('.views-row', context);
       }
       else {
+        // If no elements match any of the selectors, exit.
         return;
       }
       selector.each(function(index) {
@@ -38,7 +43,7 @@
 
         // For links within the Views table, or those with a destination
         // parameter, open in a new window instead.
-        if (href.indexOf('destination=') >= 0 || $(element).parents('table.views-table tbody').size() > 0) {
+        if (href.indexOf('destination=') >= 0 || $(element).parents('table.views-table tbody').length > 0) {
           $(element).attr('target', '_blank');
           return;
         }

--- a/references_dialog.module
+++ b/references_dialog.module
@@ -6,6 +6,43 @@
  */
 
 /**
+ * Implements hook_autoload_info().
+ */
+function references_dialog_autoload_info() {
+  return array(
+    'references_dialog_plugin_display' => 'views/references_dialog_plugin_display.inc',
+  );
+}
+
+/**
+ * Implements hook_menu().
+ */
+function references_dialog_menu() {
+  $items = array();
+  // This redirect callback is used when adding and editing content in
+  // the overlay. When content is created or edited, we are directed here,
+  // so we can act properly on entities.
+  $items['references-dialog/redirect/%/%'] = array(
+    'page callback' => 'references_dialog_redirect_page',
+    'page arguments' => array(2, 3),
+    'access callback' => 'references_dialog_redirect_access',
+    'access arguments' => array(2, 3),
+  );
+  return $items;
+}
+
+/**
+ * Implements hook_theme().
+ */
+function references_dialog_theme() {
+  return array(
+    'references_dialog_links' => array(
+      'variables' => array('links' => NULL),
+    ),
+  );
+}
+
+/**
  * Implements hook_element_info().
  */
 function references_dialog_element_info() {
@@ -40,32 +77,6 @@ function references_dialog_element_info_alter(&$info) {
       $info[$widget['element_type']]['#after_build'][] = 'references_dialog_process_widget';
     }
   }
-}
-
-/**
- * Implements hook_autoload_info().
- */
-function references_dialog_autoload_info() {
-  return array(
-    'references_dialog_plugin_display' => 'views/references_dialog_plugin_display.inc',
-  );
-}
-
-/**
- * Implements hook_menu().
- */
-function references_dialog_menu() {
-  $items = array();
-  // This redirect callback is used when adding and editing content in
-  // the overlay. When content is created or edited, we are directed here,
-  // so we can act properly on entities.
-  $items['references-dialog/redirect/%/%'] = array(
-    'page callback' => 'references_dialog_redirect_page',
-    'page arguments' => array(2, 3),
-    'access callback' => 'references_dialog_redirect_access',
-    'access arguments' => array(2, 3),
-  );
-  return $items;
 }
 
 /**
@@ -394,14 +405,14 @@ function references_dialog_js_settings($id, array $settings) {
 }
 
 /**
- * Implements hook_theme().
+ * Process variables for references_dialog_page.
  */
-function references_dialog_theme() {
-  return array(
-    'references_dialog_links' => array(
-      'variables' => array('links' => NULL),
-    ),
-  );
+function template_process_references_dialog_page(&$variables) {
+  // Generate messages last in order to capture as many as possible for the
+  // current page.
+  if (!isset($variables['messages'])) {
+   $variables['messages'] = $variables['page']['#show_messages'] ? theme('status_messages') : '';
+  }
 }
 
 /**
@@ -542,6 +553,19 @@ function references_dialog_get_views_search_links($attachable) {
   }
   return $links;
 }
+
+/**
+ * Implements hook_preprocess_page().
+  */
+function references_dialog_preprocess_page(&$variables) {
+
+  if (references_dialog_in_dialog()) {
+    unset($variables['page_bottom']);
+    $variables['page'] = '<div id="references-dialog-page">' . $variables['page'] . '</div>';
+    backdrop_add_js('file', '/js/search-reference.js',);
+  }
+}
+
 
 /**
  * Check if we are in a references dialog.

--- a/references_dialog.module
+++ b/references_dialog.module
@@ -405,17 +405,6 @@ function references_dialog_js_settings($id, array $settings) {
 }
 
 /**
- * Process variables for references_dialog_page.
- */
-function template_process_references_dialog_page(&$variables) {
-  // Generate messages last in order to capture as many as possible for the
-  // current page.
-  if (!isset($variables['messages'])) {
-   $variables['messages'] = $variables['page']['#show_messages'] ? theme('status_messages') : '';
-  }
-}
-
-/**
  * Implements hook_entity_insert().
  */
 function references_dialog_entity_insert($entity, $entity_type) {

--- a/references_dialog.module
+++ b/references_dialog.module
@@ -549,7 +549,6 @@ function references_dialog_get_views_search_links($attachable) {
 function references_dialog_preprocess_page(&$variables) {
 
   if (references_dialog_in_dialog()) {
-    unset($variables['page_bottom']);
     $variables['page'] = '<div id="references-dialog-page">' . $variables['page'] . '</div>';
     backdrop_add_js('file', '/js/search-reference.js',);
   }

--- a/views/references_dialog_plugin_display.inc
+++ b/views/references_dialog_plugin_display.inc
@@ -152,8 +152,6 @@ class references_dialog_plugin_display extends views_plugin_display {
     return $items;
   }
 
-  function uses_exposed() { return TRUE; }
-
   /**
    * Override references_plugin_display, and
    * allow for other style types.


### PR DESCRIPTION
Fixes #37 

Also, this makes dialog search working as it was working in Drupal, this is, the elements listed in the view have their links updated and clicking on one of them, the dialog window closes and the node gets added to the references field.

There were some missing functions, like hook_page, replaced with a hook_preprocess_page, and the search-dialog.js file was outdated.

I also changed the order of the functions, just to make it easier to compare with the Drupal file and see the differences.